### PR TITLE
update go.mod (#8521)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,3 +141,5 @@ replace github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => githu
 replace github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376 => github.com/matrixorigin/vfs v0.2.1-0.20220616104132-8852fd867376
 
 replace github.com/lni/goutils v1.3.1-0.20220604063047-388d67b4dbc4 => github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4
+
+replace github.com/fagongzi/goetty/v2 v2.0.3-0.20221212132037-abf2d4c05484 => github.com/matrixorigin/goetty/v2 v2.0.0-20221212132037-abf2d4c05484

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
-github.com/fagongzi/goetty/v2 v2.0.3-0.20221212132037-abf2d4c05484 h1:zTcfRC43TffcJ8Dnu7j00dvWVCaIhTTdRuJaPhGDebw=
-github.com/fagongzi/goetty/v2 v2.0.3-0.20221212132037-abf2d4c05484/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
 github.com/fagongzi/util v0.0.0-20210923134909-bccc37b5040d h1:1pILVCatHj3eVo9i52dZyY4BwjTmSIeN+/hoJh8rD0Y=
 github.com/fagongzi/util v0.0.0-20210923134909-bccc37b5040d/go.mod h1:5cqSns2zMRcJeVGvAqeTrbXFqh5AqBFr5uVKP9T2kiE=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
@@ -390,6 +388,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/matrixorigin/goetty/v2 v2.0.0-20221212132037-abf2d4c05484 h1:0RKWcsZlKfzHuhsUXZV+3hqjG+EHMC5t5UQvCkLJvtM=
+github.com/matrixorigin/goetty/v2 v2.0.0-20221212132037-abf2d4c05484/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20230322100352-2390d003ee0f h1:a2b9x3rXl92UZ4eq+p+fa6b//V6rPuSQav6qskwO57k=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20230322100352-2390d003ee0f/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4 h1:+SmZP2bG+YcO/ntzjCleCu6hFTJiue7Oj2tftpJKTlU=


### PR DESCRIPTION
The goetty has been forked under the matrixorigin group. For the future update, it is suitable to refer the goetty of the matrixorigin.

Approved by: @fengttt, @zhangxu19830126

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: